### PR TITLE
widget.go: Search for fonts rather than hardcoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/atotto/clipboard v0.1.2
 	github.com/bendahl/uinput v1.0.2
 	github.com/davecgh/go-spew v1.1.1
+	github.com/flopp/go-findfont v0.0.0-20201103071330-d960cd9a3075
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/godbus/dbus v4.1.0+incompatible
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/flopp/go-findfont v0.0.0-20201103071330-d960cd9a3075 h1:IRC2iJbtQGLRmV+bdZWZFyZeVGw1XDR4/AM7FbBISCo=
+github.com/flopp/go-findfont v0.0.0-20201103071330-d960cd9a3075/go.mod h1:wKKxRDjD024Rh7VMwoU90i6ikQRCr+JTHB5n4Ejkqvw=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/widget.go
+++ b/widget.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/flopp/go-findfont"
 	"github.com/golang/freetype"
 	"github.com/golang/freetype/truetype"
 	"github.com/muesli/streamdeck"
@@ -145,33 +146,33 @@ func drawString(img *image.RGBA, ttf *truetype.Font, text string, fontsize float
 	}
 }
 
+func loadFont(name string) (*truetype.Font, error) {
+	fontPath, err := findfont.Find(name)
+	if err != nil {
+		return nil, err
+	}
+
+	ttf, err := ioutil.ReadFile(fontPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return freetype.ParseFont(ttf)
+}
+
 func init() {
-	ttf, err := ioutil.ReadFile("/usr/share/fonts/TTF/Roboto-Regular.ttf")
+	var err error
+	ttfFont, err = loadFont("Roboto-Regular.ttf")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	ttfFont, err = freetype.ParseFont(ttf)
+	ttfThinFont, err = loadFont("Roboto-Thin.ttf")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	ttf, err = ioutil.ReadFile("/usr/share/fonts/TTF/Roboto-Thin.ttf")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	ttfThinFont, err = freetype.ParseFont(ttf)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	ttf, err = ioutil.ReadFile("/usr/share/fonts/TTF/Roboto-Bold.ttf")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	ttfBoldFont, err = freetype.ParseFont(ttf)
+	ttfBoldFont, err = loadFont("Roboto-Bold.ttf")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
:wave: thanks for writing this, I was worried I'd have to write my own thing like I did for the keylight :sweat_smile:.

I ran into a problem though - I don't have a `/usr/share/fonts` on my NixOS systems. This commit moves font loading to use go-findfont which on Linux systems will correctly load XDG_DATA_DIRs when available but still fall back to older common paths.