### PR TITLE
Add date widget to example deck config

### DIFF
--- a/decks/main.deck
+++ b/decks/main.deck
@@ -15,6 +15,11 @@
       fillColor = "#a69bd6"
 
 [[keys]]
+  index = 3
+  [keys.widget]
+    id = "date"
+
+[[keys]]
   index = 4
   [keys.widget]
     id = "clock"


### PR DESCRIPTION
Shows up left of the time widget.