### PR TITLE
Consecutive key presses

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,12 +14,12 @@ type DBusConfig struct {
 }
 
 type ActionConfig struct {
-	Deck    string     `toml:"deck,omitempty"`
-	Keycode string     `toml:"keycode,omitempty"`
-	DelayMs int        `toml:"delayms,omitempty"` // default: 0
-	Exec    string     `toml:"exec,omitempty"`
-	Paste   string     `toml:"paste,omitempty"`
-	DBus    DBusConfig `toml:"dbus,omitempty"`
+	Deck     string     `toml:"deck,omitempty"`
+	Keycode  string     `toml:"keycode,omitempty"`
+	DelaysMs []int      `toml:"delaysms,omitempty"` // default: 0
+	Exec     string     `toml:"exec,omitempty"`
+	Paste    string     `toml:"paste,omitempty"`
+	DBus     DBusConfig `toml:"dbus,omitempty"`
 }
 
 type WidgetConfig struct {

--- a/config.go
+++ b/config.go
@@ -15,12 +15,11 @@ type DBusConfig struct {
 }
 
 type ActionConfig struct {
-	Deck     string     `toml:"deck,omitempty"`
-	Keycode  string     `toml:"keycode,omitempty"`
-	DelaysMs []int      `toml:"delaysms,omitempty"`
-	Exec     string     `toml:"exec,omitempty"`
-	Paste    string     `toml:"paste,omitempty"`
-	DBus     DBusConfig `toml:"dbus,omitempty"`
+	Deck    string     `toml:"deck,omitempty"`
+	Keycode string     `toml:"keycode,omitempty"`
+	Exec    string     `toml:"exec,omitempty"`
+	Paste   string     `toml:"paste,omitempty"`
+	DBus    DBusConfig `toml:"dbus,omitempty"`
 }
 
 type WidgetConfig struct {

--- a/config.go
+++ b/config.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"bytes"
-	"github.com/BurntSushi/toml"
 	"io/ioutil"
+
+	"github.com/BurntSushi/toml"
 )
 
 type DBusConfig struct {

--- a/config.go
+++ b/config.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
-
 	"github.com/BurntSushi/toml"
+	"io/ioutil"
 )
 
 type DBusConfig struct {
@@ -17,6 +16,7 @@ type DBusConfig struct {
 type ActionConfig struct {
 	Deck    string     `toml:"deck,omitempty"`
 	Keycode string     `toml:"keycode,omitempty"`
+	DelayMs int        `toml:"delayms,omitempty"` // default: 0
 	Exec    string     `toml:"exec,omitempty"`
 	Paste   string     `toml:"paste,omitempty"`
 	DBus    DBusConfig `toml:"dbus,omitempty"`

--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ type DBusConfig struct {
 type ActionConfig struct {
 	Deck     string     `toml:"deck,omitempty"`
 	Keycode  string     `toml:"keycode,omitempty"`
-	DelaysMs []int      `toml:"delaysms,omitempty"` // default: 0
+	DelaysMs []int      `toml:"delaysms,omitempty"`
 	Exec     string     `toml:"exec,omitempty"`
 	Paste    string     `toml:"paste,omitempty"`
 	DBus     DBusConfig `toml:"dbus,omitempty"`

--- a/deck.go
+++ b/deck.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
+	"github.com/atotto/clipboard"
+	"github.com/godbus/dbus"
 	"log"
 	"os/exec"
 	"strconv"
 	"strings"
-
-	"github.com/atotto/clipboard"
-	"github.com/godbus/dbus"
+	"time"
 )
 
 // Deck is a set of widgets.
@@ -41,7 +41,7 @@ func emulateKeyPress(keys string) {
 
 	kk := strings.Split(keys, "-")
 	for i, k := range kk {
-		kc, err := strconv.Atoi(k)
+		kc, err := strconv.Atoi(strings.TrimSpace(k))
 		if err != nil {
 			log.Fatalf("%s is not a valid keycode: %s", k, err)
 		}
@@ -55,6 +55,25 @@ func emulateKeyPress(keys string) {
 	}
 }
 
+// emulates a range of key presses
+func emulateKeyPresses(keys string) {
+	if keyboard == nil {
+		log.Println("Keyboard emulation is disabled!")
+		return
+	}
+
+	kkp := strings.Split(keys, "/")
+	for i, kp := range kkp {
+		println("Single Keybinding: ", kp)
+		emulateKeyPress(kp)
+		if i+1 < len(kkp) {
+			println("Sleeping")
+			// TODO: Make available from config
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
 // emulates a clipboard paste.
 func emulateClipboard(text string) {
 	err := clipboard.WriteAll(text)
@@ -63,7 +82,7 @@ func emulateClipboard(text string) {
 	}
 
 	// paste the string
-	emulateKeyPress("29-47") // ctrl-v
+	emulateKeyPresses("29-47") // ctrl-v
 }
 
 // executes a dbus method.
@@ -115,7 +134,7 @@ func (d *Deck) triggerAction(index uint8, hold bool) {
 					deck.updateWidgets()
 				}
 				if a.Keycode != "" {
-					emulateKeyPress(a.Keycode)
+					emulateKeyPresses(a.Keycode)
 				}
 				if a.Paste != "" {
 					emulateClipboard(a.Paste)

--- a/deck.go
+++ b/deck.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/atotto/clipboard"
-	"github.com/godbus/dbus"
 	"log"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/atotto/clipboard"
+	"github.com/godbus/dbus"
 )
 
 // Deck is a set of widgets.

--- a/deck.go
+++ b/deck.go
@@ -33,31 +33,23 @@ func LoadDeck(deck string) (*Deck, error) {
 	return &d, nil
 }
 
-// Handles keypress delay
+// handles keypress with delay.
 func emulateKeyPressWithDelay(keys string) {
-	if strings.Contains(keys, "+") {
-		kd := strings.Split(keys, "+")
-		key := kd[0]
-		delay, err := strconv.Atoi(strings.TrimSpace(kd[1]))
-		emulateKeyPress(key)
-		if err == nil {
-			time.Sleep(time.Duration(delay) * time.Millisecond)
-		}
-	} else {
-		emulateKeyPress(keys)
-	}
-}
-
-// emulates a range of key presses
-func emulateKeyPresses(keys string) {
-	if keyboard == nil {
-		log.Println("Keyboard emulation is disabled!")
+	kd := strings.Split(keys, "+")
+	emulateKeyPress(kd[0])
+	if len(kd) == 1 {
 		return
 	}
 
-	kkp := strings.Split(keys, "/")
+	// optional delay
+	if delay, err := strconv.Atoi(strings.TrimSpace(kd[1])); err == nil {
+		time.Sleep(time.Duration(delay) * time.Millisecond)
+	}
+}
 
-	for _, kp := range kkp {
+// emulates a range of key presses.
+func emulateKeyPresses(keys string) {
+	for _, kp := range strings.Split(keys, "/") {
 		emulateKeyPressWithDelay(kp)
 	}
 }

--- a/deck.go
+++ b/deck.go
@@ -56,7 +56,7 @@ func emulateKeyPress(keys string) {
 }
 
 // emulates a range of key presses
-func emulateKeyPresses(keys string) {
+func emulateKeyPresses(keys string, delayMs int) {
 	if keyboard == nil {
 		log.Println("Keyboard emulation is disabled!")
 		return
@@ -69,9 +69,13 @@ func emulateKeyPresses(keys string) {
 		if i+1 < len(kkp) {
 			println("Sleeping")
 			// TODO: Make available from config
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(time.Duration(delayMs) * time.Millisecond)
 		}
 	}
+}
+
+func emulateKeyPressesDefaultDelay(keys string) {
+	emulateKeyPresses(keys, 100)
 }
 
 // emulates a clipboard paste.
@@ -82,7 +86,7 @@ func emulateClipboard(text string) {
 	}
 
 	// paste the string
-	emulateKeyPresses("29-47") // ctrl-v
+	emulateKeyPressesDefaultDelay("29-47") // ctrl-v
 }
 
 // executes a dbus method.
@@ -134,7 +138,7 @@ func (d *Deck) triggerAction(index uint8, hold bool) {
 					deck.updateWidgets()
 				}
 				if a.Keycode != "" {
-					emulateKeyPresses(a.Keycode)
+					emulateKeyPresses(a.Keycode, a.DelayMs)
 				}
 				if a.Paste != "" {
 					emulateClipboard(a.Paste)


### PR DESCRIPTION
Feature Proposal:

Allows to pass several key codes that will be executed after one another. To do this, blocks of key codes are separated using `/`.

To make the key codes more readable in the config, this also introduces white-space trimming, making it possible to give `29-20/46/46/12/30/32/50/23/49/28` as `29-20 / 46 / 46 / 12 / 30 / 32 / 50 / 23 / 49 / 28`. A rewrite to using an array would be another option, but will break existing setups.

The delays are configurable, defaulting to 100ms. If not enough delay values are given, the last one is repeated.

I am a bit unsure about the location of the array helpers – they might even be provided by go somewhere, I am not that proficient with it – as well the pad handling. It is possible to reduce the cases here down to "no entry" vs. "some entry", using the padding function in both cases, but this might be less clear.

Any comment on these issues, as well as regarding naming conventions or any other concern, is really appreciated.

As for the motivation: I use this code on my setup, e.g. to interface with the browser. Issue `Ctrl`+`t` to open a new tab, wait until it is responsive (~150ms), then type some bookmark alias char by char with less delay between the events (20ms)

Thanks for this tool :+1: 