### PR TITLE
Expand tilde to home-dir for decks and images

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/atotto/clipboard"
 	"github.com/godbus/dbus"
+	"github.com/mitchellh/go-homedir"
 	"github.com/muesli/streamdeck"
 )
 
@@ -26,10 +27,14 @@ type Deck struct {
 
 // LoadDeck loads a deck configuration.
 func LoadDeck(dev *streamdeck.Device, base string, deck string) (*Deck, error) {
-	if !filepath.IsAbs(deck) {
-		deck = filepath.Join(base, deck)
+	exp, err := homedir.Expand(deck)
+	if err != nil {
+		return nil, err
 	}
-	abs, err := filepath.Abs(deck)
+	if !filepath.IsAbs(exp) {
+		exp = filepath.Join(base, exp)
+	}
+	abs, err := filepath.Abs(exp)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/jezek/xgb v0.0.0-20210312150743-0e0f116e1240
 	github.com/jezek/xgbutil v0.0.0-20210302171758-530099784e66
 	github.com/lucasb-eyer/go-colorful v1.2.0
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/muesli/streamdeck v0.2.0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/shirou/gopsutil v2.18.12+incompatible

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/muesli/streamdeck v0.2.0 h1:qAYEUdKt4rOyYzUUXZw4EHdEaQHDOW8GjVbfr37CAUs=

--- a/images.go
+++ b/images.go
@@ -2,15 +2,21 @@ package main
 
 import (
 	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 func findImage(base, icon string) string {
-	if !filepath.IsAbs(icon) {
-		icon = filepath.Join(base, icon)
-	}
-	abs, err := filepath.Abs(icon)
+	exp, err := homedir.Expand(icon)
 	if err != nil {
 		return icon
+	}
+	if !filepath.IsAbs(exp) {
+		exp = filepath.Join(base, exp)
+	}
+	abs, err := filepath.Abs(exp)
+	if err != nil {
+		return exp
 	}
 
 	return abs


### PR DESCRIPTION
This is just a little qol-feature which allows `~`-prefixed paths in `.deck` files. This should allow for a better portability of `deck` files