### PR TITLE
Add per widget update intervals with possilbe configuration in deck files

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ type ActionConfig struct {
 // WidgetConfig describes configuration data for widgets.
 type WidgetConfig struct {
 	ID       string            `toml:"id,omitempty"`
-	Interval string            `toml:"interval,omitempty"`
+	Interval uint              `toml:"interval,omitempty"`
 	Config   map[string]string `toml:"config,omitempty"`
 }
 

--- a/config.go
+++ b/config.go
@@ -26,8 +26,9 @@ type ActionConfig struct {
 
 // WidgetConfig describes configuration data for widgets.
 type WidgetConfig struct {
-	ID     string            `toml:"id,omitempty"`
-	Config map[string]string `toml:"config,omitempty"`
+	ID       string            `toml:"id,omitempty"`
+	Interval string            `toml:"interval,omitempty"`
+	Config   map[string]string `toml:"config,omitempty"`
 }
 
 // KeyConfig holds the entire configuration for a single key.

--- a/deck.go
+++ b/deck.go
@@ -60,7 +60,7 @@ func LoadDeck(dev *streamdeck.Device, base string, deck string) (*Deck, error) {
 
 		var w Widget
 		if k, found := keyMap[i]; found {
-			w = NewWidget(k.Index, k.Widget.ID, k.Action, k.ActionHold, bg, k.Widget.Config)
+			w = NewWidget(k.Index, k.Widget.ID, k.Widget.Interval, k.Action, k.ActionHold, bg, k.Widget.Config)
 		} else {
 			w = NewBaseWidget(i, nil, nil, bg)
 		}
@@ -241,6 +241,9 @@ func (d *Deck) triggerAction(dev *streamdeck.Device, index uint8, hold bool) {
 // updateWidgets updates/repaints all the widgets.
 func (d *Deck) updateWidgets(dev *streamdeck.Device) {
 	for _, w := range d.Widgets {
+		if !w.RequiresUpdate() {
+			continue
+		}
 		if err := w.Update(dev); err != nil {
 			log.Fatalf("error: %v", err)
 		}

--- a/deck.go
+++ b/deck.go
@@ -60,7 +60,7 @@ func LoadDeck(dev *streamdeck.Device, base string, deck string) (*Deck, error) {
 
 		var w Widget
 		if k, found := keyMap[i]; found {
-			w = NewWidget(k.Index, k.Widget.ID, k.Widget.Interval, k.Action, k.ActionHold, bg, k.Widget.Config)
+			w = NewWidget(k, bg)
 		} else {
 			w = NewBaseWidget(i, nil, nil, bg)
 		}
@@ -244,6 +244,8 @@ func (d *Deck) updateWidgets(dev *streamdeck.Device) {
 		if !w.RequiresUpdate() {
 			continue
 		}
+
+		// log.Printf("Repaint %d", w.Key())
 		if err := w.Update(dev); err != nil {
 			log.Fatalf("error: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 	}
 	for {
 		select {
-		case <-time.After(900 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
 			deck.updateWidgets(&dev)
 
 		case k, ok := <-kch:
@@ -149,13 +149,11 @@ func main() {
 				}
 				continue
 			}
-			// spew.Dump(k)
 
 			var state bool
 			if ks, ok := keyStates.Load(k.Index); ok {
 				state = ks.(bool)
 			}
-			// log.Println("Storing state", k.Pressed)
 			keyStates.Store(k.Index, k.Pressed)
 
 			if state && !k.Pressed {

--- a/widget_button.go
+++ b/widget_button.go
@@ -3,7 +3,6 @@ package main
 import (
 	"image"
 	"path/filepath"
-	"sync"
 
 	"github.com/muesli/streamdeck"
 )
@@ -14,52 +13,46 @@ type ButtonWidget struct {
 	icon     string
 	label    string
 	fontsize float64
-
-	init sync.Once
 }
 
 // Update renders the widget.
 func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
 	var err error
-	w.init.Do(func() {
-		size := int(dev.Pixels)
-		margin := size / 18
-		height := size - (margin * 2)
-		img := image.NewRGBA(image.Rect(0, 0, size, size))
+	size := int(dev.Pixels)
+	margin := size / 18
+	height := size - (margin * 2)
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
 
-		if w.label != "" {
-			iconsize := int((float64(height) / 3.0) * 2.0)
-			bounds := img.Bounds()
+	if w.label != "" {
+		iconsize := int((float64(height) / 3.0) * 2.0)
+		bounds := img.Bounds()
 
-			if w.icon != "" {
-				err = drawImage(img,
-					findImage(filepath.Dir(deck.File), w.icon),
-					iconsize,
-					image.Pt(-1, margin))
-
-				bounds.Min.Y += iconsize + margin
-				bounds.Max.Y -= margin
-			}
-
-			drawString(img,
-				bounds,
-				ttfFont,
-				w.label,
-				dev.DPI,
-				w.fontsize,
-				image.Pt(-1, -1))
-		} else if w.icon != "" {
+		if w.icon != "" {
 			err = drawImage(img,
 				findImage(filepath.Dir(deck.File), w.icon),
-				height,
-				image.Pt(-1, -1))
+				iconsize,
+				image.Pt(-1, margin))
+
+			bounds.Min.Y += iconsize + margin
+			bounds.Max.Y -= margin
 		}
 
-		if err != nil {
-			return
-		}
-		err = w.render(dev, img)
-	})
+		drawString(img,
+			bounds,
+			ttfFont,
+			w.label,
+			dev.DPI,
+			w.fontsize,
+			image.Pt(-1, -1))
+	} else if w.icon != "" {
+		err = drawImage(img,
+			findImage(filepath.Dir(deck.File), w.icon),
+			height,
+			image.Pt(-1, -1))
+	}
 
-	return err
+	if err != nil {
+		return err
+	}
+	return w.render(dev, img)
 }

--- a/widget_button.go
+++ b/widget_button.go
@@ -17,7 +17,6 @@ type ButtonWidget struct {
 
 // Update renders the widget.
 func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
-	var err error
 	size := int(dev.Pixels)
 	margin := size / 18
 	height := size - (margin * 2)
@@ -28,10 +27,14 @@ func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
 		bounds := img.Bounds()
 
 		if w.icon != "" {
-			err = drawImage(img,
+			err := drawImage(img,
 				findImage(filepath.Dir(deck.File), w.icon),
 				iconsize,
 				image.Pt(-1, margin))
+
+			if err != nil {
+				return err
+			}
 
 			bounds.Min.Y += iconsize + margin
 			bounds.Max.Y -= margin
@@ -45,14 +48,15 @@ func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
 			w.fontsize,
 			image.Pt(-1, -1))
 	} else if w.icon != "" {
-		err = drawImage(img,
+		err := drawImage(img,
 			findImage(filepath.Dir(deck.File), w.icon),
 			height,
 			image.Pt(-1, -1))
+
+		if err != nil {
+			return err
+		}
 	}
 
-	if err != nil {
-		return err
-	}
 	return w.render(dev, img)
 }

--- a/widget_recent_window.go
+++ b/widget_recent_window.go
@@ -17,6 +17,15 @@ type RecentWindowWidget struct {
 	lastClass string
 }
 
+// RequiresUpdate returns true when the widget wants to be repainted.
+func (w *RecentWindowWidget) RequiresUpdate() bool {
+	if int(w.window) < len(recentWindows) {
+		return w.lastClass != recentWindows[w.window].Class
+	}
+
+	return false
+}
+
 // Update renders the widget.
 func (w *RecentWindowWidget) Update(dev *streamdeck.Device) error {
 	img := image.NewRGBA(image.Rect(0, 0, int(dev.Pixels), int(dev.Pixels)))


### PR DESCRIPTION
Just a short heads up!

This is more or less the same that I already had impelmented in #22 

I decided to place the `interval` right inside the `WidgetConfig` since this is a setting that can be applied to every widget.
I would have loved to model the `interval` as `int` but this would mean that widgets without a specified `interval` get the "default value" 0 which is not desireable.
Furthermore I'm not really happy with the `setInterval` call in every switch-case but I don't know how I could avoid this.