### PR TITLE
Allow for non-string config map values

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -60,7 +60,10 @@ func LoadDeck(dev *streamdeck.Device, base string, deck string) (*Deck, error) {
 
 		var w Widget
 		if k, found := keyMap[i]; found {
-			w = NewWidget(k, bg)
+			w, err = NewWidget(k, bg)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			w = NewBaseWidget(i, nil, nil, bg)
 		}

--- a/decks/main.deck
+++ b/decks/main.deck
@@ -12,7 +12,6 @@
     id = "top"
     [keys.widget.config]
       mode = "memory"
-      fillColor = "#a69bd6"
 
 [[keys]]
   index = 3
@@ -37,6 +36,7 @@
     [keys.widget.config]
       icon = "assets/volume-low.png"
       label = "Lower Vol"
+      fontsize = 8
   [keys.action]
     keycode = "VolumeDown"
 
@@ -47,6 +47,7 @@
     [keys.widget.config]
       icon = "assets/volume-high.png"
       label = "Raise Vol"
+      fontsize = 8
   [keys.action]
     keycode = "VolumeUp"
 
@@ -87,32 +88,32 @@
   [keys.widget]
     id = "recentWindow"
     [keys.widget.config]
-      window = "1"
+      window = 1
 
 [[keys]]
   index = 11
   [keys.widget]
     id = "recentWindow"
     [keys.widget.config]
-      window = "2"
+      window = 2
 
 [[keys]]
   index = 12
   [keys.widget]
     id = "recentWindow"
     [keys.widget.config]
-      window = "3"
+      window = 3
 
 [[keys]]
   index = 13
   [keys.widget]
     id = "recentWindow"
     [keys.widget.config]
-      window = "4"
+      window = 4
 
 [[keys]]
   index = 14
   [keys.widget]
     id = "recentWindow"
     [keys.widget.config]
-      window = "5"
+      window = 5

--- a/go.sum
+++ b/go.sum
@@ -125,7 +125,6 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/image v0.0.0-20200119044424-58c23975cae1 h1:5h3ngYt7+vXCDZCup/HkCQgW5XwmSvR/nA2JmJ0RErg=
 golang.org/x/image v0.0.0-20200119044424-58c23975cae1/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20210504121937-7319ad40d33e h1:PzJMNfFQx+QO9hrC1GwZ4BoPGeNGhfeQEgcQFArEjPk=
 golang.org/x/image v0.0.0-20210504121937-7319ad40d33e/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/widget_button.go
+++ b/widget_button.go
@@ -15,6 +15,23 @@ type ButtonWidget struct {
 	fontsize float64
 }
 
+func NewButtonWidget(bw BaseWidget, opts WidgetConfig) (*ButtonWidget, error) {
+	bw.setInterval(opts.Interval, 0)
+
+	var icon, label string
+	ConfigValue(opts.Config["icon"], &icon)
+	ConfigValue(opts.Config["label"], &label)
+	var fontsize float64
+	ConfigValue(opts.Config["fontsize"], &fontsize)
+
+	return &ButtonWidget{
+		BaseWidget: bw,
+		icon:       icon,
+		label:      label,
+		fontsize:   fontsize,
+	}, nil
+}
+
 // Update renders the widget.
 func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
 	size := int(dev.Pixels)

--- a/widget_recent_window.go
+++ b/widget_recent_window.go
@@ -17,6 +17,18 @@ type RecentWindowWidget struct {
 	lastClass string
 }
 
+func NewRecentWindowWidget(bw BaseWidget, opts WidgetConfig) (*RecentWindowWidget, error) {
+	var window int64
+	if err := ConfigValue(opts.Config["window"], &window); err != nil {
+		return nil, err
+	}
+
+	return &RecentWindowWidget{
+		BaseWidget: bw,
+		window:     uint8(window),
+	}, nil
+}
+
 // RequiresUpdate returns true when the widget wants to be repainted.
 func (w *RecentWindowWidget) RequiresUpdate() bool {
 	if int(w.window) < len(recentWindows) {

--- a/widget_time.go
+++ b/widget_time.go
@@ -17,29 +17,18 @@ type TimeWidget struct {
 	font   string
 }
 
-func formatTime(t time.Time, format string) string {
-	tm := map[string]string{
-		"%Y": "2006",
-		"%y": "06",
-		"%F": "January",
-		"%M": "Jan",
-		"%m": "01",
-		"%l": "Monday",
-		"%D": "Mon",
-		"%d": "02",
-		"%h": "03",
-		"%H": "15",
-		"%i": "04",
-		"%s": "05",
-		"%a": "PM",
-		"%t": "MST",
-	}
+func NewTimeWidget(bw BaseWidget, opts WidgetConfig) (*TimeWidget, error) {
+	bw.setInterval(opts.Interval, 500)
 
-	for k, v := range tm {
-		format = strings.ReplaceAll(format, k, v)
-	}
+	var format, font string
+	ConfigValue(opts.Config["format"], &format)
+	ConfigValue(opts.Config["font"], &font)
 
-	return t.Format(format)
+	return &TimeWidget{
+		BaseWidget: bw,
+		format:     format,
+		font:       font,
+	}, nil
 }
 
 // Update renders the widget.
@@ -74,4 +63,29 @@ func (w *TimeWidget) Update(dev *streamdeck.Device) error {
 	}
 
 	return w.render(dev, img)
+}
+
+func formatTime(t time.Time, format string) string {
+	tm := map[string]string{
+		"%Y": "2006",
+		"%y": "06",
+		"%F": "January",
+		"%M": "Jan",
+		"%m": "01",
+		"%l": "Monday",
+		"%D": "Mon",
+		"%d": "02",
+		"%h": "03",
+		"%H": "15",
+		"%i": "04",
+		"%s": "05",
+		"%a": "PM",
+		"%t": "MST",
+	}
+
+	for k, v := range tm {
+		format = strings.ReplaceAll(format, k, v)
+	}
+
+	return t.Format(format)
 }

--- a/widget_top.go
+++ b/widget_top.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"image/draw"
@@ -20,6 +21,20 @@ type TopWidget struct {
 	fillColor string
 
 	lastValue float64
+}
+
+func NewTopWidget(bw BaseWidget, opts WidgetConfig) (*TopWidget, error) {
+	bw.setInterval(opts.Interval, 500)
+
+	var mode, fillColor string
+	ConfigValue(opts.Config["mode"], &mode)
+	ConfigValue(opts.Config["fillColor"], &fillColor)
+
+	return &TopWidget{
+		BaseWidget: bw,
+		mode:       mode,
+		fillColor:  fillColor,
+	}, nil
 }
 
 // Update renders the widget.
@@ -46,7 +61,7 @@ func (w *TopWidget) Update(dev *streamdeck.Device) error {
 		label = "MEM"
 
 	default:
-		panic("Unknown widget mode: " + w.mode)
+		return fmt.Errorf("unknown widget mode: %s", w.mode)
 	}
 
 	if w.lastValue == value {
@@ -54,9 +69,12 @@ func (w *TopWidget) Update(dev *streamdeck.Device) error {
 	}
 	w.lastValue = value
 
+	if w.fillColor == "" {
+		w.fillColor = "#a69bd6"
+	}
 	fill, err := colorful.Hex(w.fillColor)
 	if err != nil {
-		panic("Invalid color: " + w.fillColor)
+		return fmt.Errorf("invalid color: %s", w.fillColor)
 	}
 
 	size := int(dev.Pixels)


### PR DESCRIPTION
The conversion is fugly, but there's no way around dynamically converting the values into the required type.
This also cleans up widget instantiation.