### PR TITLE
Fix exec path expand and small README addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ You can control the brightness, in percent:
 deckmaster -brightness 50
 ```
 
+Control a specific streamdeck:
+
+```bash
+deckmaster -device [serial number]
+```
+
 ## Configuration
 
 You can find a few example configurations in the [decks](https://github.com/muesli/deckmaster/tree/master/decks)

--- a/main.go
+++ b/main.go
@@ -48,6 +48,9 @@ func expandPath(base, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if base == "" {
+		return path, nil
+	}
 
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(base, path)


### PR DESCRIPTION
In #39 I did not pay full attention to the way `filepath.Abs()` works. This in turn broke the execution of global apps.
The exec_command `app` got prepended with the working dir of deckmaster and could therefore not be run