### PR TITLE
Improved command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ A flexible widget that can display the current time or date.
     format = "%H;%i;%s"
     font = "bold;regular;thin" # optional
     color = "#fefefe" # optional
+    layout = "0x0+72x24;0x24+72x24;0x48+72x24" # optional
 ```
+
+With `layout` custom layouts can be definded in the format `[posX]x[posY]+[width]x[height]`.
 
 Values for `format` are:
 
@@ -232,6 +235,7 @@ A widget that displays the output of commands.
     command = "echo 'Files:'; ls -a ~ | wc -l"
     font = "regular;bold" # optional
     color = "#fefefe" # optional
+    layout = "0x0+72x20;0x20+72x52" # optional
 ```
 
 #### Weather

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	colorful "github.com/lucasb-eyer/go-colorful"
@@ -134,6 +135,28 @@ func ConfigValue(v interface{}, dst interface{}) error {
 			*d = x
 		default:
 			return fmt.Errorf("unhandled type %+v for color.Color conversion", reflect.TypeOf(vt))
+		}
+
+	case *[]string:
+		switch vt := v.(type) {
+		case string:
+			*d = strings.Split(vt, ";")
+		default:
+			return fmt.Errorf("unhandled type %+v for []string conversion", reflect.TypeOf(vt))
+		}
+
+	case *[]color.Color:
+		switch vt := v.(type) {
+		case string:
+			cls := strings.Split(vt, ";")
+			var clrs []color.Color
+			for _, cl := range cls {
+				clr, _ := colorful.Hex(cl)
+				clrs = append(clrs, clr)
+			}
+			*d = clrs
+		default:
+			return fmt.Errorf("unhandled type %+v for []color.Color conversion", reflect.TypeOf(vt))
 		}
 
 	default:

--- a/deck.go
+++ b/deck.go
@@ -59,12 +59,12 @@ func LoadDeck(dev *streamdeck.Device, base string, deck string) (*Deck, error) {
 
 		var w Widget
 		if k, found := keyMap[i]; found {
-			w, err = NewWidget(filepath.Dir(path), k, bg)
+			w, err = NewWidget(dev, filepath.Dir(path), k, bg)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			w = NewBaseWidget(filepath.Dir(path), i, nil, nil, bg)
+			w = NewBaseWidget(dev, filepath.Dir(path), i, nil, nil, bg)
 		}
 
 		d.Widgets = append(d.Widgets, w)
@@ -223,7 +223,7 @@ func (d *Deck) triggerAction(dev *streamdeck.Device, index uint8, hold bool) {
 					}
 
 					deck = d
-					deck.updateWidgets(dev)
+					deck.updateWidgets()
 				}
 				if a.Keycode != "" {
 					emulateKeyPresses(a.Keycode)
@@ -245,14 +245,14 @@ func (d *Deck) triggerAction(dev *streamdeck.Device, index uint8, hold bool) {
 }
 
 // updateWidgets updates/repaints all the widgets.
-func (d *Deck) updateWidgets(dev *streamdeck.Device) {
+func (d *Deck) updateWidgets() {
 	for _, w := range d.Widgets {
 		if !w.RequiresUpdate() {
 			continue
 		}
 
 		// fmt.Println("Repaint", w.Key())
-		if err := w.Update(dev); err != nil {
+		if err := w.Update(); err != nil {
 			fatalf("error: %v\n", err)
 		}
 	}

--- a/layouts.go
+++ b/layouts.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"image"
+	"strconv"
+	"strings"
+)
+
+// Layout contains the data to represent the layout of the widget.
+type Layout struct {
+	frames []image.Rectangle
+	size   int
+	margin int
+	height int
+}
+
+// NewLayout returns a new Layout with the accoriding size.
+func NewLayout(size int) *Layout {
+	margin := size / 18
+	height := size - (margin * 2)
+
+	return &Layout{
+		size:   size,
+		margin: margin,
+		height: height,
+	}
+}
+
+// DefaultLayout returns a layout that is evenly split in frameCount horziontal containers.
+func (l *Layout) DefaultLayout(frameCount int) []image.Rectangle {
+	if frameCount < 1 {
+		frameCount = 1
+	}
+	for i := 0; i < frameCount; i++ {
+		frame := l.defaultFrame(frameCount, i)
+		l.frames = append(l.frames, frame)
+	}
+	return l.frames
+}
+
+// FormatLayout returns a layout that is formatted according to frameReps.
+func (l *Layout) FormatLayout(frameReps []string, frameCount int) []image.Rectangle {
+	if frameCount < 1 {
+		frameCount = 1
+	}
+	for i := 0; i < frameCount; i++ {
+		if len(frameReps) < i+1 {
+			frame := l.defaultFrame(frameCount, i)
+			l.frames = append(l.frames, frame)
+			continue
+		}
+
+		frame, err := formatFrame(frameReps[i])
+		if err != nil {
+			fmt.Println("using default frame: ", err)
+			frame = l.defaultFrame(frameCount, i)
+		}
+		l.frames = append(l.frames, frame)
+	}
+	return l.frames
+}
+
+// Returns the Rectangle representing the index-th horizontal cell.
+func (l *Layout) defaultFrame(cells int, index int) image.Rectangle {
+	lower := l.margin + (l.height/cells)*index
+	upper := l.margin + (l.height/cells)*(index+1)
+	return image.Rect(0, lower, l.size, upper)
+}
+
+// Converts the string representation of a rectangle into a image.Rectangle.
+func formatFrame(layout string) (image.Rectangle, error) {
+	split := strings.Split(layout, "+")
+	if len(split) < 2 {
+		return image.Rectangle{}, fmt.Errorf("invalid rectangle format")
+	}
+	position, errP := formatCoord(split[0])
+	if errP != nil {
+		return image.Rectangle{}, errP
+	}
+	extent, errE := formatCoord(split[1])
+	if errE != nil {
+		return image.Rectangle{}, errE
+	}
+
+	return image.Rectangle{position, position.Add(extent)}, nil
+}
+
+// Converts the string representation of a point into a image.Point.
+func formatCoord(coords string) (image.Point, error) {
+	split := strings.Split(coords, "x")
+	if len(split) < 2 {
+		return image.Point{}, fmt.Errorf("invalid point format")
+	}
+	posX, errX := strconv.Atoi(split[0])
+	posY, errY := strconv.Atoi(split[1])
+	if errX != nil || errY != nil {
+		return image.Point{}, fmt.Errorf("invalid point format")
+	}
+	return image.Pt(posX, posY), nil
+}

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func eventLoop(dev *streamdeck.Device, tch chan interface{}) {
 	for {
 		select {
 		case <-time.After(100 * time.Millisecond):
-			deck.updateWidgets(dev)
+			deck.updateWidgets()
 
 		case k, ok := <-kch:
 			if !ok {
@@ -112,7 +112,7 @@ func eventLoop(dev *streamdeck.Device, tch chan interface{}) {
 		case e := <-tch:
 			switch event := e.(type) {
 			case WindowClosedEvent:
-				handleWindowClosed(dev, event)
+				handleWindowClosed(event)
 
 			case ActiveWindowChangedEvent:
 				handleActiveWindowChanged(dev, event)
@@ -213,7 +213,7 @@ func main() {
 	if err != nil {
 		fatal(err)
 	}
-	deck.updateWidgets(dev)
+	deck.updateWidgets()
 
 	eventLoop(dev, tch)
 }

--- a/widget.go
+++ b/widget.go
@@ -24,7 +24,7 @@ var (
 type Widget interface {
 	Key() uint8
 	RequiresUpdate() bool
-	Update(dev *streamdeck.Device) error
+	Update() error
 	Action() *ActionConfig
 	ActionHold() *ActionConfig
 	TriggerAction(hold bool)
@@ -36,6 +36,7 @@ type BaseWidget struct {
 	key        uint8
 	action     *ActionConfig
 	actionHold *ActionConfig
+	dev        *streamdeck.Device
 	background image.Image
 	lastUpdate time.Time
 	interval   time.Duration
@@ -73,24 +74,25 @@ func (w *BaseWidget) RequiresUpdate() bool {
 }
 
 // Update renders the widget.
-func (w *BaseWidget) Update(dev *streamdeck.Device) error {
-	return w.render(dev, nil)
+func (w *BaseWidget) Update() error {
+	return w.render(w.dev, nil)
 }
 
 // NewBaseWidget returns a new BaseWidget.
-func NewBaseWidget(base string, index uint8, action, actionHold *ActionConfig, bg image.Image) *BaseWidget {
+func NewBaseWidget(dev *streamdeck.Device, base string, index uint8, action, actionHold *ActionConfig, bg image.Image) *BaseWidget {
 	return &BaseWidget{
 		base:       base,
 		key:        index,
 		action:     action,
 		actionHold: actionHold,
+		dev:        dev,
 		background: bg,
 	}
 }
 
 // NewWidget initializes a widget.
-func NewWidget(base string, kc KeyConfig, bg image.Image) (Widget, error) {
-	bw := NewBaseWidget(base, kc.Index, kc.Action, kc.ActionHold, bg)
+func NewWidget(dev *streamdeck.Device, base string, kc KeyConfig, bg image.Image) (Widget, error) {
+	bw := NewBaseWidget(dev, base, kc.Index, kc.Action, kc.ActionHold, bg)
 
 	switch kc.Widget.ID {
 	case "button":

--- a/widget_button.go
+++ b/widget_button.go
@@ -4,8 +4,6 @@ import (
 	"image"
 	"image/color"
 	"time"
-
-	"github.com/muesli/streamdeck"
 )
 
 // ButtonWidget is a simple widget displaying an icon and/or label.
@@ -77,8 +75,8 @@ func (w *ButtonWidget) SetImage(img image.Image) {
 }
 
 // Update renders the widget.
-func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
-	size := int(dev.Pixels)
+func (w *ButtonWidget) Update() error {
+	size := int(w.dev.Pixels)
 	margin := size / 18
 	height := size - (margin * 2)
 	img := image.NewRGBA(image.Rect(0, 0, size, size))
@@ -105,7 +103,7 @@ func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
 			bounds,
 			ttfFont,
 			w.label,
-			dev.DPI,
+			w.dev.DPI,
 			w.fontsize,
 			w.color,
 			image.Pt(-1, -1))
@@ -120,5 +118,5 @@ func (w *ButtonWidget) Update(dev *streamdeck.Device) error {
 		}
 	}
 
-	return w.render(dev, img)
+	return w.render(w.dev, img)
 }

--- a/widget_recent_window.go
+++ b/widget_recent_window.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 	"image"
-
-	"github.com/muesli/streamdeck"
 )
 
 // RecentWindowWidget is a widget displaying a recently activated window.
@@ -48,8 +46,8 @@ func (w *RecentWindowWidget) RequiresUpdate() bool {
 }
 
 // Update renders the widget.
-func (w *RecentWindowWidget) Update(dev *streamdeck.Device) error {
-	img := image.NewRGBA(image.Rect(0, 0, int(dev.Pixels), int(dev.Pixels)))
+func (w *RecentWindowWidget) Update() error {
+	img := image.NewRGBA(image.Rect(0, 0, int(w.dev.Pixels), int(w.dev.Pixels)))
 
 	if int(w.window) < len(recentWindows) {
 		if w.lastID == recentWindows[w.window].ID {
@@ -67,10 +65,10 @@ func (w *RecentWindowWidget) Update(dev *streamdeck.Device) error {
 
 		w.label = name
 		w.SetImage(recentWindows[w.window].Icon)
-		return w.ButtonWidget.Update(dev)
+		return w.ButtonWidget.Update()
 	}
 
-	return w.render(dev, img)
+	return w.render(w.dev, img)
 }
 
 // TriggerAction gets called when a button is pressed.

--- a/widget_top.go
+++ b/widget_top.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/muesli/streamdeck"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
 )
@@ -43,7 +42,7 @@ func NewTopWidget(bw *BaseWidget, opts WidgetConfig) *TopWidget {
 }
 
 // Update renders the widget.
-func (w *TopWidget) Update(dev *streamdeck.Device) error {
+func (w *TopWidget) Update() error {
 	var value float64
 	var label string
 
@@ -81,7 +80,7 @@ func (w *TopWidget) Update(dev *streamdeck.Device) error {
 		w.fillColor = color.RGBA{166, 155, 182, 255}
 	}
 
-	size := int(dev.Pixels)
+	size := int(w.dev.Pixels)
 	margin := size / 18
 	img := image.NewRGBA(image.Rect(0, 0, size, size))
 
@@ -107,7 +106,7 @@ func (w *TopWidget) Update(dev *streamdeck.Device) error {
 		bounds,
 		ttfFont,
 		strconv.FormatInt(int64(value), 10),
-		dev.DPI,
+		w.dev.DPI,
 		13,
 		w.color,
 		image.Pt(-1, -1))
@@ -121,10 +120,10 @@ func (w *TopWidget) Update(dev *streamdeck.Device) error {
 		bounds,
 		ttfFont,
 		"% "+label,
-		dev.DPI,
+		w.dev.DPI,
 		-1,
 		w.color,
 		image.Pt(-1, -1))
 
-	return w.render(dev, img)
+	return w.render(w.dev, img)
 }

--- a/widget_weather.go
+++ b/widget_weather.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/muesli/streamdeck"
 )
 
 //go:embed assets/weather
@@ -160,16 +158,16 @@ func (w *WeatherWidget) RequiresUpdate() bool {
 }
 
 // Update renders the widget.
-func (w *WeatherWidget) Update(dev *streamdeck.Device) error {
+func (w *WeatherWidget) Update() error {
 	go w.data.Fetch()
 
 	cond, err := w.data.Condition()
 	if err != nil {
-		return w.render(dev, nil)
+		return w.render(w.dev, nil)
 	}
 	temp, err := w.data.Temperature()
 	if err != nil {
-		return w.render(dev, nil)
+		return w.render(w.dev, nil)
 	}
 
 	var iconName string
@@ -199,7 +197,7 @@ func (w *WeatherWidget) Update(dev *streamdeck.Device) error {
 			iconName = "sun"
 		}
 	default:
-		return w.render(dev, nil)
+		return w.render(w.dev, nil)
 	}
 
 	var weatherIcon image.Image
@@ -218,7 +216,7 @@ func (w *WeatherWidget) Update(dev *streamdeck.Device) error {
 	w.label = temp
 	w.SetImage(weatherIcon)
 
-	return w.ButtonWidget.Update(dev)
+	return w.ButtonWidget.Update()
 }
 
 func formatUnit(unit string) string {

--- a/window.go
+++ b/window.go
@@ -27,10 +27,10 @@ func handleActiveWindowChanged(dev *streamdeck.Device, event ActiveWindowChanged
 	if len(recentWindows) > keys {
 		recentWindows = recentWindows[0:keys]
 	}
-	deck.updateWidgets(dev)
+	deck.updateWidgets()
 }
 
-func handleWindowClosed(dev *streamdeck.Device, event WindowClosedEvent) {
+func handleWindowClosed(event WindowClosedEvent) {
 	i := 0
 	for _, rw := range recentWindows {
 		if rw.ID == event.Window.ID {
@@ -41,5 +41,5 @@ func handleWindowClosed(dev *streamdeck.Device, event WindowClosedEvent) {
 		i++
 	}
 	recentWindows = recentWindows[:i]
-	deck.updateWidgets(dev)
+	deck.updateWidgets()
 }


### PR DESCRIPTION
I wanted to add some more abilities for customization to widget_command. Since the current implementation is fairly restrictive.

Most of the work in `Update` was for no reason repeated every iteration so I moved most of it into the "constructor" (could be done for other widgets as well).
This means I can save the final correct typed values (font, color, ...) directly in CommandWidget and save time in `Update`.

~~`config.go` got therefore some new values and we may think about adding the `Rectangle` part in widget_command to `config.go` as well since this could be used for other widgets as well (widget_time)?~~

Edit: I have moved the layout logic into a separate file since it can be used in at least two widgets so far. Currently the "layout" is supported for `widget_command` and `widget_time`.

For now the implementation allows by intention frames that are not fully inside the button because `DrawString` does not allow for text alignment. The currently used frame format is `[posX]x[posY]+[width]x[height]`.

What are your thoughts on all these changes?

Off topic: Do you also have artifacts when using colored widgets. For example using the time widget with the color `#ff0000` does result in red areas apart from the text itself.