### PR TITLE
Fix documentation of interval attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ and left to right.
 
 #### Update interval for widgets
 
-A widget can optionally be set to update at a defined interval.
+Optionally, you can configure an update `interval` for each widget:
 
 ```toml
 [keys.widget]
@@ -153,7 +153,8 @@ A widget can optionally be set to update at a defined interval.
   interval = 500 # optional
 ```
 
-The attribute `interval` defines the time in `ms` between two consecutive updates of the widget. The default interval in `500`
+The attribute `interval` defines the time in `ms` between two consecutive
+updates of a widget.
 
 #### Button
 

--- a/README.md
+++ b/README.md
@@ -137,13 +137,23 @@ Any widget is build up the following way:
 ```toml
 [[keys]]
   index = 0
-  interval = 500 # optional
 ```
 
 `index` needs to be present in every widget and describes the position of the
 widget on the streamdeck. `index` is 0-indexed and counted from top to bottom
-and left to right. The attribute `interval` defines the time in `ms` between two
-consecutive updates of the widget.
+and left to right.
+
+#### Update interval for widgets
+
+A widget can optionally be set to update at a defined interval.
+
+```toml
+[keys.widget]
+  id = "button"
+  interval = 500 # optional
+```
+
+The attribute `interval` defines the time in `ms` between two consecutive updates of the widget. The default interval in `500`
 
 #### Button
 


### PR DESCRIPTION
Interval attribute was listed as being under keys section, but it needs to be put under keys.widget section (Issue #47 )