### PR TITLE
Modified to reset and close the Stream Deck on panic or termination signal

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -253,7 +253,7 @@ func (d *Deck) updateWidgets() {
 
 		// fmt.Println("Repaint", w.Key())
 		if err := w.Update(); err != nil {
-			fatalf("error: %v\n", err)
+			fatalf("error: %v", err)
 		}
 	}
 }

--- a/fonts.go
+++ b/fonts.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"io/ioutil"
+	"os"
 
 	"github.com/flopp/go-findfont"
 	"github.com/golang/freetype"
@@ -86,16 +88,19 @@ func init() {
 	var err error
 	ttfFont, err = loadFont("Roboto-Regular.ttf")
 	if err != nil {
-		fatal(err)
+		fmt.Fprintln(os.Stderr, "Error loading font:", err)
+		os.Exit(1)
 	}
 
 	ttfThinFont, err = loadFont("Roboto-Thin.ttf")
 	if err != nil {
-		fatal(err)
+		fmt.Fprintln(os.Stderr, "Error loading font:", err)
+		os.Exit(1)
 	}
 
 	ttfBoldFont, err = loadFont("Roboto-Bold.ttf")
 	if err != nil {
-		fatal(err)
+		fmt.Fprintln(os.Stderr, "Error loading font:", err)
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -171,23 +171,20 @@ func initDevice() (*streamdeck.Device, error) {
 	}
 	ver, err := dev.FirmwareVersion()
 	if err != nil {
-		closeDevice(&dev)
-		return nil, err
+		return &dev, err
 	}
 	fmt.Printf("Found device with serial %s (%d buttons, firmware %s)\n",
 		dev.Serial, dev.Keys, ver)
 
 	if err := dev.Reset(); err != nil {
-		closeDevice(&dev)
-		return nil, err
+		return &dev, err
 	}
 
 	if *brightness > 100 {
 		*brightness = 100
 	}
 	if err = dev.SetBrightness(uint8(*brightness)); err != nil {
-		closeDevice(&dev)
-		return nil, err
+		return &dev, err
 	}
 
 	return &dev, nil
@@ -198,10 +195,12 @@ func main() {
 
 	// initialize device
 	dev, err := initDevice()
+	if dev != nil {
+		defer closeDevice(dev)
+	}
 	if err != nil {
 		fatal(err)
 	}
-	defer closeDevice(dev)
 
 	// initialize dbus connection
 	dbusConn, err = dbus.SessionBus()


### PR DESCRIPTION
1. I deferred a reset/close of the Stream Deck on return from main
2. I changed the os.Exit calls in the fatal and fatalf functions to panic so that the defer from above is called
3. I added signal handling to eventLoop to catch Control-C and kill -15 so that the defer from above is called