### PR TITLE
Added brightness control actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,29 @@ A list of available `keycodes` can be found here: [keycodes](https://github.com/
     value = "value"
 ```
 
+#### Device actions
+
+Increase the brightness. If no value is specified, it will be increased by 10%.
+
+```toml
+[keys.action]
+  device = "brightness+5"
+```
+
+Decrease the brightness. If no value is specified, it will be decreased by 10%.
+
+```toml
+[keys.action]
+  device = "brightness-5"
+```
+
+Set the brightness to a specific value between 0 and 100.
+
+```toml
+[keys.action]
+  device = "brightness=50"
+```
+
 ## More Decks!
 
 [deckmaster-emojis](https://github.com/muesli/deckmaster-emojis), an Emoji keyboard deck

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type ActionConfig struct {
 	Keycode string     `toml:"keycode,omitempty"`
 	Exec    string     `toml:"exec,omitempty"`
 	Paste   string     `toml:"paste,omitempty"`
+	Device  string     `toml:"device,omitempty"`
 	DBus    DBusConfig `toml:"dbus,omitempty"`
 }
 

--- a/decks/main.deck
+++ b/decks/main.deck
@@ -66,9 +66,9 @@
     id = "button"
     [keys.widget.config]
       icon = "assets/go-previous.png"
-      label = "Prev Act"
+      label = "Dim"
   [keys.action]
-    exec = "kactivities-cli --previous-activity"
+    device = "brightness-10"
 
 [[keys]]
   index = 9
@@ -76,9 +76,9 @@
     id = "button"
     [keys.widget.config]
       icon = "assets/go-next.png"
-      label = "Next Act"
+      label = "Brighten"
   [keys.action]
-    exec = "kactivities-cli --next-activity"
+    device = "brightness+10"
 
 [[keys]]
   index = 10


### PR DESCRIPTION
1. Added a `special` key action type
2. Added `bright=N`, `bright+N`, and `bright-N` special actions to control the brightness

Note: there is a slight overlap with #58 because both need this `special` key action type.  It shouldn't be too bad to resolve merge conflicts here unless you want to do this type of action differently.