### PR TITLE
Fixed improper truncation in the middle of a Unicode codepoint.

### DIFF
--- a/widget_recent_window.go
+++ b/widget_recent_window.go
@@ -58,8 +58,9 @@ func (w *RecentWindowWidget) Update() error {
 		var name string
 		if w.showTitle {
 			name = recentWindows[w.window].Name
-			if len(name) > 10 {
-				name = name[:10]
+			runes := []rune(name)
+			if len(runes) > 10 {
+				name = string(runes[:10])
 			}
 		}
 


### PR DESCRIPTION
This fixes a bug that allows truncation of the window title in the middle of a Unicode codepoint which causes the "tofu" symbol to appear indicating an invalid character.