### PR TITLE
Add sleep timeout flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Control a specific streamdeck:
 deckmaster -device [serial number]
 ```
 
+Set a sleep timeout after which the screen gets turned off:
+
+```bash
+deckmaster -sleep 10m
+```
+
 ## Configuration
 
 You can find a few example configurations in the [decks](https://github.com/muesli/deckmaster/tree/master/decks)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jezek/xgbutil v0.0.0-20210302171758-530099784e66
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/muesli/streamdeck v0.2.2
+	github.com/muesli/streamdeck v0.2.3-0.20220205114833-1d5ef99e6a4e
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/muesli/streamdeck v0.2.2 h1:V0Orzjo2tPzO7nBtIcZVH/Bt0qhJYu0BzExjktL8qdw=
-github.com/muesli/streamdeck v0.2.2/go.mod h1:VnSRlfQP7FH1GRcVJY/kV6MofesFPVPaSOJLa08JeqE=
+github.com/muesli/streamdeck v0.2.3-0.20220205114833-1d5ef99e6a4e h1:ZNBSoWM+CUfjoLCZHbYHCM2EDfpo6HggzxlXBqCo/BI=
+github.com/muesli/streamdeck v0.2.3-0.20220205114833-1d5ef99e6a4e/go.mod h1:VnSRlfQP7FH1GRcVJY/kV6MofesFPVPaSOJLa08JeqE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	deckFile   = flag.String("deck", "main.deck", "path to deck config file")
 	device     = flag.String("device", "", "which device to use (serial number)")
 	brightness = flag.Uint("brightness", 80, "brightness in percent")
+	sleep      = flag.String("sleep", "", "sleep timeout")
 )
 
 const (
@@ -188,6 +189,15 @@ func initDevice() (*streamdeck.Device, error) {
 	}
 	if err = dev.SetBrightness(uint8(*brightness)); err != nil {
 		return &dev, err
+	}
+
+	if len(*sleep) > 0 {
+		timeout, err := time.ParseDuration(*sleep)
+		if err != nil {
+			return &dev, err
+		}
+
+		dev.SetSleepTimeout(timeout)
 	}
 
 	return &dev, nil


### PR DESCRIPTION
When enabled, the device screen will turn off automatically after the specified period of inactivity has elapsed.