### PR TITLE
Add verbose flag and clean up printing to stdout/stderr

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -29,7 +29,7 @@ func LoadDeck(dev *streamdeck.Device, base string, deck string) (*Deck, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("Loading deck:", path)
+	verbosef("Loading deck: %s", path)
 
 	dc, err := LoadConfig(path)
 	if err != nil {
@@ -188,12 +188,17 @@ func executeCommand(cmd string) {
 		cmd = exp
 	}
 	args := strings.Split(cmd, " ")
+
 	c := exec.Command(args[0], args[1:]...) //nolint:gosec
+	if *verbose {
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+	}
+
 	if err := c.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Command failed: %s\n", err)
 		return
 	}
-
 	if err := c.Wait(); err != nil {
 		fmt.Fprintf(os.Stderr, "Command failed: %s\n", err)
 	}

--- a/desktop_unix.go
+++ b/desktop_unix.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package main
@@ -256,7 +257,7 @@ func (x Xorg) waitForEvent(events chan<- xgb.Event) {
 	for {
 		ev, err := x.conn.WaitForEvent()
 		if err != nil {
-			fmt.Println("wait for event:", err)
+			verbosef("wait for event: %s", err)
 			continue
 		}
 		events <- ev
@@ -267,7 +268,7 @@ func (x Xorg) waitForEvent(events chan<- xgb.Event) {
 func (x Xorg) queryIdle() time.Duration {
 	info, err := screensaver.QueryInfo(x.conn, xproto.Drawable(x.root)).Reply()
 	if err != nil {
-		fmt.Println("query idle:", err)
+		fmt.Fprintln(os.Stderr, "query idle:", err)
 		return 0
 	}
 	return time.Duration(info.MsSinceUserInput) * time.Millisecond

--- a/layouts.go
+++ b/layouts.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"image"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -53,7 +54,7 @@ func (l *Layout) FormatLayout(frameReps []string, frameCount int) []image.Rectan
 
 		frame, err := formatFrame(frameReps[i])
 		if err != nil {
-			fmt.Println("using default frame: ", err)
+			fmt.Fprintln(os.Stderr, "using default frame:", err)
 			frame = l.defaultFrame(frameCount, i)
 		}
 		l.frames = append(l.frames, frame)

--- a/widget_recent_window.go
+++ b/widget_recent_window.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"image"
+	"os"
 )
 
 // RecentWindowWidget is a widget displaying a recently activated window.
@@ -75,7 +76,7 @@ func (w *RecentWindowWidget) Update() error {
 // TriggerAction gets called when a button is pressed.
 func (w *RecentWindowWidget) TriggerAction(hold bool) {
 	if xorg == nil {
-		fmt.Println("xorg support is disabled!")
+		fmt.Fprintln(os.Stderr, "xorg support is disabled!")
 		return
 	}
 

--- a/widget_weather.go
+++ b/widget_weather.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"image"
 	"io/ioutil"
-	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -58,7 +58,7 @@ func (w *WeatherData) Condition() (string, error) {
 
 	w.ready = false
 	if strings.Contains(w.response, "Unknown location") {
-		fmt.Println("unknown location:", w.location)
+		fmt.Fprintln(os.Stderr, "unknown location:", w.location)
 		return "", nil
 	}
 
@@ -77,7 +77,7 @@ func (w *WeatherData) Temperature() (string, error) {
 
 	w.ready = false
 	if strings.Contains(w.response, "Unknown location") {
-		fmt.Println("unknown location:", w.location)
+		fmt.Fprintln(os.Stderr, "unknown location:", w.location)
 		return "", nil
 	}
 
@@ -105,20 +105,20 @@ func (w *WeatherData) Fetch() {
 	if time.Since(w.refresh) < time.Minute*15 {
 		return
 	}
-	// fmt.Println("Refreshing weather data...")
+	verbosef("Refreshing weather data...")
 
 	url := "http://wttr.in/" + w.location + "?format=%x+%t" + formatUnit(w.unit)
 
 	resp, err := http.Get(url) //nolint:gosec
 	if err != nil {
-		fmt.Println("can't fetch weather data:", err)
+		fmt.Fprintln(os.Stderr, "can't fetch weather data:", err)
 		return
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println("can't read weather data:", err)
+		fmt.Fprintln(os.Stderr, "can't read weather data:", err)
 		return
 	}
 
@@ -206,7 +206,7 @@ func (w *WeatherWidget) Update() error {
 		var err error
 		weatherIcon, err = loadThemeImage(w.theme, iconName)
 		if err != nil {
-			log.Println("using fallback icons")
+			fmt.Fprintln(os.Stderr, "weather widget using fallback icons")
 			weatherIcon = weatherImage(imagePath)
 		}
 	} else {

--- a/window.go
+++ b/window.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/muesli/streamdeck"
 )
 
 func handleActiveWindowChanged(dev *streamdeck.Device, event ActiveWindowChangedEvent) {
-	fmt.Printf("Active window changed to %s (%d, %s)\n",
+	verbosef("Active window changed to %s (%d, %s)",
 		event.Window.Class, event.Window.ID, event.Window.Name)
 
 	// remove dupes


### PR DESCRIPTION
Adds a `-verbose` flag that enables more detailed output. This will connect the stdout/stderr of any sub-command executed with deckmaster's stdout/stderr.

Fixes #64.