### PR TITLE
Embraces no-args dbus methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,25 @@ A list of available `keycodes` can be found here: [keycodes](https://github.com/
 #### Trigger a dbus call
 
 ```toml
-[keys.action]
-  [dbus]
-    object = "object"
-    path = "path"
-    method = "method"
-    value = "value"
+[keys.action.dbus]
+  object = "object"
+  path = "path"
+  method = "method"
+  value = "value"  # omit this for no-arg methods
 ```
+
+For example this: `dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.PlayPause`
+
+Translates to this:
+
+```toml
+[keys.action.dbus]
+  object = "org.mpris.MediaPlayer2.spotify"
+  path = "/org/mpris/MediaPlayer2"
+  method = "org.mpris.MediaPlayer2.Player.PlayPause"
+  #value = ""
+```
+
 
 #### Device actions
 

--- a/config.go
+++ b/config.go
@@ -17,10 +17,10 @@ import (
 
 // DBusConfig describes a dbus action.
 type DBusConfig struct {
-	Object string `toml:"object,omitempty"`
-	Path   string `toml:"path,omitempty"`
-	Method string `toml:"method,omitempty"`
-	Value  string `toml:"value,omitempty"`
+	Object string  `toml:"object,omitempty"`
+	Path   string  `toml:"path,omitempty"`
+	Method string  `toml:"method,omitempty"`
+	Value  *string `toml:"value,omitempty"`
 }
 
 // ActionConfig describes an action that can be triggered.

--- a/deck.go
+++ b/deck.go
@@ -175,8 +175,13 @@ func emulateClipboard(text string) {
 }
 
 // executes a dbus method.
-func executeDBusMethod(object, path, method, args string) {
-	call := dbusConn.Object(object, dbus.ObjectPath(path)).Call(method, 0, args)
+func executeDBusMethod(object, path, method string, args *string) {
+	var call *dbus.Call
+	if args == nil {
+		call = dbusConn.Object(object, dbus.ObjectPath(path)).Call(method, 0)
+	} else {
+		call = dbusConn.Object(object, dbus.ObjectPath(path)).Call(method, 0, args)
+	}
 	if call.Err != nil {
 		fmt.Fprintf(os.Stderr, "dbus call failed: %s\n", call.Err)
 	}


### PR DESCRIPTION
It wasn't possible to call dbus methods that take no arguments.

Also updated the README to document the new possibility.