### PR TITLE
Implement ImageCommand

### DIFF
--- a/widget.go
+++ b/widget.go
@@ -122,6 +122,9 @@ func NewWidget(dev *streamdeck.Device, base string, kc KeyConfig, bg image.Image
 	case "command":
 		return NewCommandWidget(bw, kc.Widget), nil
 
+	case "imageCommand":
+		return NewCommandImageWidget(bw, kc.Widget), nil
+
 	case "weather":
 		return NewWeatherWidget(bw, kc.Widget)
 	}

--- a/widget_command_image.go
+++ b/widget_command_image.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"image"
+	"os"
+	"time"
+)
+
+type CommandImageWidget struct {
+	*BaseWidget
+	commands []string
+}
+
+// NewCommandImageWidget returns a new CommandImageWidget.
+func NewCommandImageWidget(bw *BaseWidget, opts WidgetConfig) *CommandImageWidget {
+	bw.setInterval(time.Duration(opts.Interval)*time.Millisecond, time.Second)
+
+	var commands []string
+	_ = ConfigValue(opts.Config["command"], &commands)
+
+	return &CommandImageWidget{
+		BaseWidget: bw,
+		commands:   commands,
+	}
+}
+
+func (w *CommandImageWidget) Update() error {
+	size := int(w.dev.Pixels)
+	margin := size / 18
+	height := size - (margin * 2)
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+
+	str, err3 := runCommand(w.commands[0])
+	if err3 != nil {
+		fmt.Fprintf(os.Stderr, "Running command failed: %s\n", err3)
+
+		return err3
+	}
+	icon, err := loadImage(str)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Loading Image failed: %s\n", err)
+	} else {
+		err2 := drawImage(img,
+			icon,
+			height,
+			image.Pt(-1, -1))
+		if err2 != nil {
+			return w.render(w.dev, img)
+		}
+	}
+
+	return w.render(w.dev, img)
+}


### PR DESCRIPTION
This is my attempt of implementing a Command which doesn't return a String but an Image.

First time coding go, so  this is most likely not how you're  supposed  to do this, and it will probably need some changes.

How it works is by getting a  path to image from a command, it will then  render this image.


Configuration is basically the same as with the Command
```
[[keys]]
  index = 13
  [keys.widget]
    id = "imageCommand"
    [keys.widget.config]
      command = "/home/damian/deck/image-updated.bash"
  [keys.action]
    exec = "/usr/sbin/youtube-music"
```

Just my example script with  which I tested this feature:
```bash
#!/bin/bash
IMAGEURL=$(playerctl metadata -p youtube-music mpris:artUrl 2< /dev/null)

if [[ $(< /tmp/artUrl.txt) != "$IMAGEURL" ]]; then
    wget "${IMAGEURL}" -O /tmp/musicimage -q
    # save IMAGEURL to /tmp/artUrl.txt
    echo "${IMAGEURL}" > /tmp/artUrl.txt
fi
echo /tmp/musicimage
```

