### PR TITLE
Fix DBus method call example

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,12 +330,11 @@ A list of available `keycodes` can be found here: [keycodes](https://github.com/
 #### Trigger a dbus call
 
 ```toml
-[keys.action]
-  [dbus]
-    object = "object"
-    path = "path"
-    method = "method"
-    value = "value"
+[keys.action.dbus]
+  object = "object"
+  path = "path"
+  method = "method"
+  value = "value"
 ```
 
 #### Device actions


### PR DESCRIPTION
Previous version example resulted in not information being read regarding DBus calls, making all DBus calls non-functional. Whether root cause of this is a bug or not, new example does work.